### PR TITLE
Fixed a typo in the dependency address in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Go library for accessing the Platform.sh environment.
 
 ## Install
 
-Add a dependency on`github.com/platforsh/gohelper` to your application.  Download it using the vendoring tool of your choice.
+Add a dependency on `github.com/platformsh/gohelper` to your application.  Download it using the vendoring tool of your choice.
 
 
 ## Usage


### PR DESCRIPTION
Hello,

I've fixed a typo, going from `platforsh` -> `platformsh`.

Lucas